### PR TITLE
Fix E2E tests to become more robust

### DIFF
--- a/frontend/cypress/integration/tests/cancelvisit/cancelvisit.spec.js
+++ b/frontend/cypress/integration/tests/cancelvisit/cancelvisit.spec.js
@@ -9,6 +9,7 @@ const eventEnd = set(new Date(eventDate), { hours: 12 })
 
 Given('there is an available event in more than two weeks ahead', () => {
   cy.request('http://localhost:3001/reset')
+  cy.intercept('POST', 'http://localhost:3001/graphql').as('GraphQL')
   cy.login({ username: 'Admin', password: 'salainen' })
   cy.createEvent({
     title: eventName,
@@ -19,6 +20,9 @@ Given('there is an available event in more than two weeks ahead', () => {
     inPersonVisit: false,
     desc: 'Test event description'
   })
+  cy.wait('@GraphQL')
+  cy.visit('http://localhost:3000')
+  cy.wait('@GraphQL')
   cy.wait(500)
 })
 

--- a/frontend/cypress/integration/tests/createuser.feature
+++ b/frontend/cypress/integration/tests/createuser.feature
@@ -1,4 +1,4 @@
-Feature: As a admin I want to create a new user
+Feature: As an admin I want to create a new user
 
 Scenario: A new user is succesfully created by an admin with valid information
     Given Admin is logged in

--- a/frontend/cypress/integration/tests/createvisit/createvisit.spec.js
+++ b/frontend/cypress/integration/tests/createvisit/createvisit.spec.js
@@ -13,6 +13,7 @@ const unavailableEventDate = addBusinessDays(set(new Date(), { hours: 10, minute
 
 it('Initialize tests', () => {
   cy.request('http://localhost:3001/reset')
+  cy.intercept('POST', 'http://localhost:3001/graphql').as('GraphQL')
   cy.login({ username: 'Admin', password: 'salainen' })
   cy.createEvent({
     title: availableEvent1,
@@ -52,10 +53,13 @@ it('Initialize tests', () => {
     end: new Date(unavailableEventDate.setHours(12,0)),
     desc: 'Unavailable event description'
   })
+  cy.wait('@GraphQL')
+  cy.visit('http://localhost:3000')
 })
 
 Given('I am on the front page', () => {
   cy.visit('http://localhost:3000')
+  cy.wait(1000)
 })
 
 And('there is an event 1 more than two weeks ahead', () => {
@@ -150,9 +154,10 @@ And('valid information is entered and visit mode selected', () => {
   cy.get('#startTime').type('10:00')
   cy.get('.privacyPolicy > input').click()
   cy.get('.remoteVisitGuidelines > input').click()
+  cy.intercept('POST', 'http://localhost:3001/graphql').as('GraphQL')
   cy.get('#create').click()
-  cy.wait(2000)
-  cy.visit('http://localhost:3000')
+  cy.wait('@GraphQL')
+  cy.contains('Poistu').click()
 })
 
 And('valid information is entered and visit mode predetermined', () => {
@@ -167,9 +172,10 @@ And('valid information is entered and visit mode predetermined', () => {
   cy.get('#startTime').type('10:00')
   cy.get('.privacyPolicy > input').click()
   cy.get('.remoteVisitGuidelines > input').click()
+  cy.intercept('POST', 'http://localhost:3001/graphql').as('GraphQL')
   cy.get('#create').click()
-  cy.wait(2000)
-  cy.visit('http://localhost:3000')
+  cy.wait('@GraphQL')
+  cy.contains('Poistu').click()
 })
 
 Then('booked event turns grey in calendar view', () => {
@@ -199,6 +205,7 @@ Then('an error message is shown', () => {
 Given('admin logs in', () => {
   cy.login({ username: 'Admin', password: 'salainen' })
   cy.get('.level > .button').should('have.text', 'Kirjaudu ulos')
+  cy.contains(unavailableEventName)
 })
 
 Then('unavailable event page contains booking button', () => {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -113,10 +113,6 @@ Cypress.Commands.add('createEvent', ({ title, scienceClass, remoteVisit, inPerso
       }
     `
     }
-  }).then(({ body }) => {
-    console.log(body)
-    cy.log(body)
-    cy.visit('http://localhost:3000')
   })
 })
 


### PR DESCRIPTION
Add intercepts for graphQL and proper waits for correct elements. The problem was that the test did not wait for the events to appear in the calendar after visiting the front page.