### PR TITLE
Backend functionality for custom forms

### DIFF
--- a/backend/graphql/resolvers.js
+++ b/backend/graphql/resolvers.js
@@ -58,7 +58,7 @@ const resolvers = {
       const extras = await Extra.find({})
       return extras
     },
-    getForm: async (root, args, { currentUser }) => {
+    getForm: async (root, args) => {
       try {
         const form = await Form.findById(args.id)
         return form
@@ -66,11 +66,14 @@ const resolvers = {
         throw new UserInputError('Form not found!')
       }
     },
-    getForms: async (root, args, { currentUser }) => {
+    getForms: async () => {
       const forms = await Form.find({})
       return forms
     },
     getFormSubmissions: async (root, args, { currentUser }) => {
+      if (!currentUser) {
+        throw new AuthenticationError('not authenticated or no credentials')
+      }
       try {
         const formSubmissions = await Form.findById(args.id).populate('submissions')
         return formSubmissions
@@ -79,6 +82,9 @@ const resolvers = {
       }
     },
     getFormSubmission: async (root, args, { currentUser }) => {
+      if (!currentUser) {
+        throw new AuthenticationError('not authenticated or no credentials')
+      }
       try {
         const formValues = await FormSubmissions.findById(args.id)
         return formValues

--- a/backend/graphql/resolvers.js
+++ b/backend/graphql/resolvers.js
@@ -11,6 +11,8 @@ const Event = require('../models/event')
 const Visit = require('../models/visit')
 const Extra = require('../models/extra')
 const Tag = require('../models/tag')
+const Form = require('../models/forms')
+const FormSubmissions = require('../models/formSubmissions')
 const { addNewTags } = require('../utils/helpers')
 
 const resolvers = {
@@ -55,6 +57,34 @@ const resolvers = {
     getExtras: async () => {
       const extras = await Extra.find({})
       return extras
+    },
+    getForm: async (root, args, { currentUser }) => {
+      try {
+        const form = await Form.findById(args.id)
+        return form
+      } catch (e) {
+        throw new UserInputError('Form not found!')
+      }
+    },
+    getForms: async (root, args, { currentUser }) => {
+      const forms = await Form.find({})
+      return forms
+    },
+    getFormSubmissions: async (root, args, { currentUser }) => {
+      try {
+        const formSubmissions = await Form.findById(args.id).populate('submissions')
+        return formSubmissions
+      } catch (error) {
+        throw new UserInputError('Form submissions not found!')
+      }
+    },
+    getFormSubmission: async (root, args, { currentUser }) => {
+      try {
+        const formValues = await FormSubmissions.findById(args.id)
+        return formValues
+      } catch (e) {
+        throw new UserInputError('Form submission not found!')
+      }
     }
   },
   Visit: {
@@ -62,6 +92,12 @@ const resolvers = {
       const event = await Event.findById(root.event).populate('tags', { name: 1, id: 1 }).populate('extras')
       return event
     },
+  },
+  Form: {
+    fields: (form) => JSON.stringify(form.fields)
+  },
+  FormSubmissions: {
+    values: (submission) => JSON.stringify(submission.values)
   },
   Mutation: {
     createUser: async (root, args, { currentUser }) => {
@@ -349,6 +385,60 @@ const resolvers = {
         return 'Deleted user with ID ' + args.id
       } catch (error) {
         throw new UserInputError('User deletion failed')
+      }
+    },
+    createForm: async (root, args, { currentUser }) => {
+      if (!currentUser) {
+        throw new AuthenticationError('not authenticated')
+      }
+      try {
+        const newForm = new Form({
+          name: args.name,
+          fields: JSON.parse(args.fields)
+        })
+        const savedForm = await newForm.save()
+        return savedForm
+      } catch (error) {
+        throw new UserInputError(error.message, { invalidArgs: args })
+      }
+    },
+    updateForm: async (root, args, { currentUser }) => {
+      if (!currentUser) {
+        throw new AuthenticationError('not authenticated')
+      }
+      try {
+        const form = await Form.findById(args.id)
+        form.name = args.name
+        form.fields = JSON.parse(args.fields)
+        form.markModified('fields')
+        await form.save()
+        return form
+      } catch (error) {
+        throw new UserInputError(error.message, { invalidArgs: args })
+      }
+    },
+    deleteForm: async (root, args, { currentUser }) => {
+      if (!currentUser) {
+        throw new AuthenticationError('not authenticated')
+      }
+      try {
+        await Form.deleteOne({ _id: args.id })
+        return 'Deleted form with ID ' + args.id
+      } catch (error) {
+        throw new UserInputError('Form deletion failed')
+      }
+    },
+    createFormSubmission: async (root, args) => {
+      try {
+        const form = await Form.findById(args.formID)
+        const newFormSubmissions = new FormSubmissions({
+          form,
+          values: JSON.parse(args.values)
+        })
+        const savedFormSubmissions = await newFormSubmissions.save()
+        return savedFormSubmissions
+      } catch (error) {
+        throw new UserInputError(error.message, { invalidArgs: args })
       }
     }
   }

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -63,6 +63,16 @@ const typeDefs = gql`
   type Token {
     value: String!
   }
+  type Form {
+    id: ID!
+    name: String!
+    fields: String!
+  }
+  type FormSubmissions {
+    id: ID
+    form: Form
+    values: String
+  }
   type Query {
     getUsers: [User]!
     me: User!
@@ -71,6 +81,10 @@ const typeDefs = gql`
     getVisits: [Visit]
     getTags: [Tag]!
     getExtras: [Extra]!
+    getForm(id: ID): Form
+    getForms: [Form]
+    getFormSubmissions(formID: ID): FormSubmissions
+    getFormSubmission(id: ID): FormSubmissions
   }
   input TagInput {
     id: String
@@ -152,6 +166,22 @@ const typeDefs = gql`
     ): String
     deleteUser(
       id: String!
+    ): String
+    createForm(
+      name: String!
+      fields: String
+    ): Form
+    createFormSubmission(
+      formID: ID
+      values: String
+    ): FormSubmissions
+    updateForm(
+      id: ID!
+      name: String!
+      fields: String
+    ): Form
+    deleteForm(
+      id: ID!
     ): String
   }
 `

--- a/backend/models/formSubmissions.js
+++ b/backend/models/formSubmissions.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose')
+const uniqueValidator = require('mongoose-unique-validator')
+
+const formSubmissionsSchema = mongoose.Schema({
+  form: {
+    type: mongoose.Schema.Types.ObjectId,
+    required: true,
+    ref: 'Form'
+  },
+  values: {
+    type: mongoose.Schema.Types.Mixed,
+    required: true,
+  }
+})
+
+formSubmissionsSchema.set('toJSON', {
+  transform: (document, returnedObject) => {
+    returnedObject.id = returnedObject._id.toString()
+    delete returnedObject._id
+    delete returnedObject.__v
+  }
+})
+
+formSubmissionsSchema.plugin(uniqueValidator,)
+
+module.exports = mongoose.model('FormSubmissions', formSubmissionsSchema)

--- a/backend/models/forms.js
+++ b/backend/models/forms.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose')
+const uniqueValidator = require('mongoose-unique-validator')
+
+const formSchema = mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  fields: {
+    type: [mongoose.Schema.Types.Mixed],
+    required: false,
+    maxLength: 10
+  },
+  submissions: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'FormSubmissions'
+    }
+  ]
+})
+
+formSchema.set('toJSON', {
+  transform: (document, returnedObject) => {
+    returnedObject.id = returnedObject._id.toString()
+    delete returnedObject._id
+    delete returnedObject.__v
+  }
+})
+
+formSchema.plugin(uniqueValidator,)
+
+module.exports = mongoose.model('Form', formSchema)

--- a/backend/tests/formExtras.test.js
+++ b/backend/tests/formExtras.test.js
@@ -1,0 +1,199 @@
+const mongoose = require('mongoose')
+const { createTestClient } = require('apollo-server-testing')
+const { ApolloServer } = require('apollo-server-express')
+const bcrypt = require('bcrypt')
+
+const UserModel = require('../models/user')
+const FormModel = require('../models/forms')
+const FormSubmissionsModel = require('../models/formSubmissions')
+const typeDefs = require('../graphql/typeDefs')
+const resolvers = require('../graphql/resolvers')
+const { CREATE_FORM, UPDATE_FORM, DELETE_FORM, CREATE_FORM_SUBMISSION } = require('./testHelpers')
+
+let adminUserData
+let serverAdmin
+
+beforeAll(async () => {
+  // connect to database
+  await mongoose.connect(process.env.MONGO_URL,
+    { useNewUrlParser: true, useCreateIndex: true, useUnifiedTopology: true, useFindAndModify: false })
+    .then(() => {
+      console.log('connected to test-mongodb')
+    })
+    .catch((error) => {
+      console.log('connection error: ', error.message)
+    })
+  await UserModel.deleteMany({})
+  await FormSubmissionsModel.deleteMany({})
+  await FormModel.deleteMany({})
+
+  const adminPassword = await bcrypt.hash('admin-password', 10)
+  adminUserData = { username: 'admin', passwordHash: adminPassword, isAdmin: true }
+  const adminUser = new UserModel(adminUserData)
+  const savedAdminUser = await adminUser.save()
+  expect(savedAdminUser.isAdmin).toBe(adminUser.isAdmin)
+
+  serverAdmin = new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: async () => {
+      const currentUser = savedAdminUser
+      return { currentUser }
+    }
+  })
+})
+
+describe('Form model test', () => {
+
+  it('Form can be created', async () => {
+    const formData = {
+      name: 'Test form',
+      fields: [
+        { name: 'username',
+          type: 'text',
+          validation: { required: true, min: 1, max: null },
+        },
+        { name: 'email',
+          type: 'text',
+          validation: { required: true, min: 5, max: null, email: true },
+        }
+      ]
+    }
+    const form = new FormModel(formData)
+    const savedForm = await form.save()
+    expect(savedForm._id).toBeDefined()
+    expect(savedForm.name).toBe(formData.name)
+    expect(savedForm.fields.length).toBe(2)
+    expect(savedForm.fields[0]).toBe(formData.fields[0])
+    expect(savedForm.fields[1]).toBe(formData.fields[1])
+  })
+
+})
+
+describe('Form server test', () => {
+
+  it('Current user can create a new form successfully', async () => {
+    const { mutate } = createTestClient(serverAdmin)
+    const response = await mutate({
+      mutation: CREATE_FORM,
+      variables: {
+        name: 'Test form 2',
+        fields: JSON.stringify([
+          { name: 'username',
+            type: 'text',
+            validation: { required: true, min: 1, max: null },
+          },
+          { name: 'email',
+            type: 'text',
+            validation: { required: true, min: 5, max: null, email: true },
+          }
+        ])
+      }
+    })
+    expect(response.errors).toBeUndefined()
+  })
+
+  it('Current user can update a form successfully', async () => {
+    const { mutate } = createTestClient(serverAdmin)
+    const form = await FormModel.findOne({})
+    const response = await mutate({
+      mutation: UPDATE_FORM,
+      variables: {
+        id: form._id.toString(),
+        name: 'Test form 2 updated',
+        fields: JSON.stringify([
+          { name: 'username',
+            type: 'text',
+            validation: { required: true, min: 1, max: null },
+          },
+          { name: 'email2',
+            type: 'text',
+            validation: { required: true, min: 5, max: null, email: true },
+          }
+        ])
+      }
+    })
+    expect(response.errors).toBeUndefined()
+  })
+
+  it('Current user can delete a form successfully', async () => {
+    const { mutate } = createTestClient(serverAdmin)
+    const form = await FormModel.findOne({})
+    const response = await mutate({
+      mutation: DELETE_FORM,
+      variables: {
+        id: form._id.toString()
+      }
+    })
+    expect(response.errors).toBeUndefined()
+  })
+})
+
+describe('Form Submissions model test', () => {
+  it('Form submission can be created', async () => {
+    const formData = {
+      name: 'Test form for submissions',
+      fields: [
+        { name: 'username',
+          type: 'text',
+          validation: { required: true, min: 1, max: null },
+        },
+        { name: 'email',
+          type: 'text',
+          validation: { required: true, min: 5, max: null, email: true },
+        }
+      ]
+    }
+    const form = new FormModel(formData)
+    const savedForm = await form.save()
+    const submissionData = {
+      form: savedForm._id,
+      values: [
+        {
+          name: 'username', value: 'tester'
+        },
+        {
+          name: 'email', value: 'test@example.com'
+        }
+      ]
+    }
+    const submission = new FormSubmissionsModel(submissionData)
+    const savedSubmission = await submission.save()
+    expect(savedSubmission._id).toBeDefined()
+    expect(savedSubmission.form).toEqual(savedForm._id)
+    expect(savedSubmission.values[0]).toBe(submissionData.values[0])
+    expect(savedSubmission.values[1]).toBe(submissionData.values[1])
+  })
+
+})
+
+describe('Form Submissions server test', () => {
+  it('Form submission can be created', async () => {
+    const { mutate } = createTestClient(serverAdmin)
+    const form = await FormModel.findOne({})
+    const values = [
+      {
+        name: 'username', value: 'tester'
+      },
+      {
+        name: 'email', value: 'test@example.com'
+      }
+    ]
+    const response = await mutate({
+      mutation: CREATE_FORM_SUBMISSION,
+      variables: {
+        formID: form._id.toString(),
+        values: JSON.stringify(values)
+      }
+    })
+    expect(response.errors).toBeUndefined()
+  })
+})
+
+afterAll(async () => {
+  await UserModel.deleteMany({})
+  await FormSubmissionsModel.deleteMany({})
+  await FormModel.deleteMany({})
+  await mongoose.connection.close()
+  console.log('test-mongodb connection closed')
+})

--- a/backend/tests/testHelpers.js
+++ b/backend/tests/testHelpers.js
@@ -360,6 +360,87 @@ const UPDATE_EVENT = gql`
   }
 `
 
+const GET_ALL_FORMS = gql`
+  query {
+    getForms {
+      id
+      name
+      fields
+    }
+  }
+`
+
+const GET_FORM = gql`
+  query getForm($id: ID!) {
+    getForm(id: $id) {
+      id
+      name
+      fields
+    }
+  }
+`
+
+const CREATE_FORM = gql`
+  mutation createForm($name: String!, $fields: String) {
+    createForm(
+      name: $name
+      fields: $fields
+    ) {
+      id
+      name
+      fields
+    }
+  }
+`
+
+const UPDATE_FORM = gql`
+  mutation updateForm($id: ID!, $name: String!, $fields: String) {
+    updateForm(
+      id: $id
+      name: $name
+      fields: $fields
+    ) {
+      id
+      name
+      fields
+    }
+  }
+`
+
+const DELETE_FORM = gql`
+  mutation deleteForm($id: ID!) {
+    deleteForm(
+      id: $id
+    )
+  }
+`
+
+const CREATE_FORM_SUBMISSION = gql`
+  mutation createFormSubmission($formID: ID!, $values: String) {
+    createFormSubmission(
+      formID: $formID
+      values: $values
+    ) {
+      id
+      form {
+        id
+      }
+      values
+    }
+  }
+`
+
+const GET_FORM_SUBMISSIONS = gql`
+  query getFormSubmissions($formID: ID!) {
+    getFormSubmissions(
+      formID: $formID
+    ) {
+      id
+      values
+    }
+  }
+`
+
 module.exports = {
   LOGIN,
   GET_ALL_VISITS,
@@ -373,7 +454,14 @@ module.exports = {
   CREATE_USER,
   USERS,
   ME,
+  GET_ALL_FORMS,
+  GET_FORM,
   UPDATE_EVENT,
+  CREATE_FORM,
+  UPDATE_FORM,
+  DELETE_FORM,
+  CREATE_FORM_SUBMISSION,
+  GET_FORM_SUBMISSIONS,
   createTimeList,
   createAvailableList,
   createDate,


### PR DESCRIPTION
Lisätty backendiin toiminnallisuus luoda custom-lomakkeita ja vastauksia niihin. Jest-testit tehty myös.
Seuraavaksi pitää tehdä frontendiin toiminnot lomakkeiden muokkaukseen.

GraphQL:n yli nuo lomakkeiden fields-tiedot liikkuvat JSON-stringinä, jotka pitää ottaa fronttiin sisään JSON.parse-toiminnolla. Muokkauksen jälkeen tiedot syötetään takaisin JSON.stringifyllä. Resolveri hoitaa muunnoksen ennen mongoon kirjoittamista. Sama idea on sitten aikanaan lomakkeeseen vastaamisessa.

