### PR TITLE
Event groups

### DIFF
--- a/backend/graphql/resolvers.js
+++ b/backend/graphql/resolvers.js
@@ -160,22 +160,42 @@ const resolvers = {
         throw new UserInputError('Backend problem')
       }
     },
-    /* assignEventToGroup: async (root, args, { currentUser }) => {
+    assignEventsToGroup: async (root, args, { currentUser }) => {
       if (!currentUser) {
         throw new AuthenticationError('not authenticated')
       }
-      const event = await Event.findById(args.event)
-      const group = await Group.findOne({ name: args.groupName })
-      if (!group || !event) {
-        throw new UserInputError('no group or event found')
+      let returnedEvents = []
+      for (let e of args.events) {
+        const event = await Event.findById(e)
+        console.log(event, '<------- event')
+        if (event) {
+          let group
+          const oldGroup = await Group.findById(event.group)
+          console.log(oldGroup, '<------- oldGroup')
+          if (oldGroup) {
+            oldGroup.events = oldGroup.events.filter(e => e.toString() !== event.id)
+            event.group = null
+          }
+          if (args.group) {
+            group = await Group.findById(args.group)
+            console.log(group, '<------- group')
+            if (group) {
+              event.group = group.id
+              group.events = group.events.concat(event.id)
+            }
+          }
+          await event.save()
+          if (group) await group.save()
+          if (oldGroup) await oldGroup.save()
+          console.log(event, '<------- eventNEW')
+          console.log(oldGroup, '<------- oldGroupNEW')
+          console.log(group, '<------- groupNEW')
+          returnedEvents.push(event)
+        }
       }
-      event.group = group.id
-      group.events = group.events.concat(event.id)
-      await event.save()
-      await group.save()
-      return event
+      return returnedEvents
     },
-    removeEventFromGroup: async (root, args, { currentUser }) => {
+    removeEventsFromGroup: async (root, args, { currentUser }) => {
       if (!currentUser) {
         throw new AuthenticationError('not authenticated')
       }
@@ -188,7 +208,7 @@ const resolvers = {
       await event.save()
       await group.save()
       return event
-    }, */
+    },
     updateEmail: async (root, args, { currentUser }) => {
       if (!currentUser || !currentUser.isAdmin) {
         throw new AuthenticationError('not authenticated or no credentials')
@@ -388,20 +408,6 @@ const resolvers = {
           group.events = group.events.concat(event.id)
         }
       }
-
-      /* let group
-      const oldGroup = await Group.findById(event.group)
-      console.log(oldGroup.id, args.group, typeof oldGroup.id, typeof args.group)
-      if (oldGroup && oldGroup.id !== args.group) {
-        oldGroup.events.filter(e => e.toString() !== event.group)
-      }
-      if (args.group) {
-        group = await Group.findById(args.group)
-        if (group) {
-          event.group = group.id
-          group.events = group.events.concat(event.id)
-        }
-      } */
 
       title !== undefined ? event.title = title : null
       desc !== undefined ? event.desc = desc : null

--- a/backend/graphql/resolvers.js
+++ b/backend/graphql/resolvers.js
@@ -124,7 +124,7 @@ const resolvers = {
     fields: (form) => JSON.stringify(form.fields)
   },
   Group: {
-    publishDate: (group) => new Date(group.publishDate).toISOString()
+    publishDate: (group) => group.publishDate ? new Date(group.publishDate).toISOString() : null
   },
   Mutation: {
     createGroup: async (root, args, { currentUser }) => {
@@ -135,7 +135,7 @@ const resolvers = {
         name: args.name,
         maxCount: args.maxCount,
         visitCount: 0,
-        publishDate: args.publishDate ? new Date(args.publishDate) : null,
+        publishDate: args.publishDate ? new Date(args.publishDate) : undefined,
         events: [],
         disabled: false
       })
@@ -146,7 +146,7 @@ const resolvers = {
       if (!currentUser) {
         throw new AuthenticationError('not authenticated')
       }
-      const group = await Group.findById(args.group)
+      const group = await Group.findById(args.id)
       group.name = args.name ? args.name : group.name
       group.maxCount = group.visitCount <= args.maxCount ? args.maxCount : group.maxCount
       group.publishDate = args.publishDate ? new Date(args.publishDate) : group.publishDate

--- a/backend/graphql/resolvers.js
+++ b/backend/graphql/resolvers.js
@@ -78,7 +78,7 @@ const resolvers = {
       if (!currentUser) {
         throw new AuthenticationError('Not authenticated')
       }
-      const groups = await Group.find({})
+      const groups = await Group.find({}).populate('events')
       return groups
     },
     findVisit: async (root, args) => {
@@ -156,12 +156,11 @@ const resolvers = {
         throw new AuthenticationError('not authenticated')
       }
       const event = await Event.findById(args.event)
+      if (!event) throw new UserInputError('no event found')
       const group = await Group.findById(event.group)
-      if (!group || !event) {
-        throw new UserInputError('no group or event found')
-      }
+      if (!group) throw new UserInputError('no group or event found')
       event.group = null
-      group.events = group.events.filter(event => event !== args.event)
+      group.events = group.events.filter(event => event.toString() !== args.event)
       await event.save()
       await group.save()
       return event

--- a/backend/graphql/resolvers.js
+++ b/backend/graphql/resolvers.js
@@ -245,7 +245,7 @@ const resolvers = {
       if (args.title.length < 5)  throw new UserInputError('title too short')
       if (new Date(args.start).getTime() < set(new Date(args.start), { hours: 8, minutes: 0, seconds: 0 }).getTime()) throw new UserInputError('invalid start time')
       if (new Date(args.end).getTime() > set(new Date(args.end), { hours: 17, minutes: 0, seconds: 0 }).getTime()) throw new UserInputError('invalid end time')
-
+      const group = await Group.findById(args.group)
       const mongoTags = await addNewTags(args.tags)
 
       const extras = await Extra.find({ _id: { $in: args.extras } })
@@ -273,6 +273,11 @@ const resolvers = {
 
       event.extras = extras
       event.tags = mongoTags
+      if (group) {
+        group.events = group.events.concat(event.id)
+        event.group = group.id
+        await group.save()
+      }
       await event.save()
       pubsub.publish('EVENT_CREATED', {
         eventModified: Object.assign(event.toJSON(), { locked: event.reserved ? true : false })

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -124,12 +124,12 @@ const typeDefs = gql`
     deleteGroup(
       group: ID!
     ): String
-    assignEventToGroup(
-      event: ID!
-      groupName: String!
-    ): Event
-    removeEventFromGroup(
-      event: ID!
+    assignEventsToGroup(
+      events: [ID]
+      group: ID!
+    ): [Event]
+    removeEventsFromGroup(
+      events: [ID]
     ): Event
     updateEmail(
       name: String!

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -170,6 +170,7 @@ const typeDefs = gql`
       extras: [ID]
       duration: Int!
       customForm: ID
+      group: ID
     ): Event
     modifyEvent(
       event: ID!

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -116,8 +116,9 @@ const typeDefs = gql`
       publishDate: String
     ): Group
     modifyGroup(
+      id: ID!
       name: String
-      maxCount: String
+      maxCount: Int
       publishDate: String
       disabled: Boolean
     ): Group

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -85,6 +85,7 @@ const typeDefs = gql`
     visitCount: Int!
     events: [Event]
     publishDate: String
+    disabled: Boolean
   }
   type EmailTemplate {
     html: String!
@@ -114,6 +115,15 @@ const typeDefs = gql`
       maxCount: Int!
       publishDate: String
     ): Group
+    modifyGroup(
+      name: String
+      maxCount: String
+      publishDate: String
+      disabled: Boolean
+    ): Group
+    removeGroup(
+      group: ID!
+    ): String
     assignEventToGroup(
       event: ID!
       groupName: String!

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -121,7 +121,7 @@ const typeDefs = gql`
       publishDate: String
       disabled: Boolean
     ): Group
-    removeGroup(
+    deleteGroup(
       group: ID!
     ): String
     assignEventToGroup(
@@ -199,6 +199,7 @@ const typeDefs = gql`
       #waitingTime: Int!
       #duration: Int!
       customForm: ID
+      group: ID
     ): Event
     createVisit(
       event: ID!

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -48,6 +48,7 @@ const typeDefs = gql`
     customForm: ID
     disabled: Boolean!
     locked: Boolean!
+    group: ID
   }
   type Visit {
     id: ID!
@@ -77,6 +78,14 @@ const typeDefs = gql`
     name: String!
     fields: String!
   }
+  type Group {
+    id: ID!
+    name: String!
+    maxCount: Int!
+    visitCount: Int!
+    events: [Event]
+    publishDate: String
+  }
   type EmailTemplate {
     html: String!
     text: String!
@@ -97,8 +106,21 @@ const typeDefs = gql`
     getForm(id: ID): Form
     getForms: [Form]
     getEmailTemplates: [EmailTemplate]
+    getGroups: [Group]
   }
   type Mutation {
+    createGroup(
+      name: String!
+      maxCount: Int!
+      publishDate: String
+    ): Group
+    assignEventToGroup(
+      event: ID!
+      groupName: String!
+    ): Event
+    removeEventFromGroup(
+      event: ID!
+    ): Event
     updateEmail(
       name: String!
       html: String!

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -48,7 +48,7 @@ const typeDefs = gql`
     customForm: ID
     disabled: Boolean!
     locked: Boolean!
-    group: ID
+    group: Group
   }
   type Visit {
     id: ID!

--- a/backend/graphql/typeDefs.js
+++ b/backend/graphql/typeDefs.js
@@ -128,9 +128,6 @@ const typeDefs = gql`
       events: [ID]
       group: ID!
     ): [Event]
-    removeEventsFromGroup(
-      events: [ID]
-    ): Event
     updateEmail(
       name: String!
       html: String!

--- a/backend/models/event.js
+++ b/backend/models/event.js
@@ -85,6 +85,11 @@ const eventSchema = mongoose.Schema({
   },
   reserved: {
     type: String
+  },
+  group: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Group',
+    required: false
   }
 })
 

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose')
+const uniqueValidator = require('mongoose-unique-validator')
+
+const groupSchema = mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    unique: true,
+    minlength: 3
+  },
+  maxCount: {
+    type: Number,
+    required: true
+  },
+  visitCount: {
+    type: Number,
+    required: true
+  },
+  events: [
+    {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Event'
+    }
+  ],
+  publishDate: {
+    type: Date,
+    required: false
+  }
+})
+
+groupSchema.set('toJSON', {
+  transform: (document, returnedObject) => {
+    returnedObject.id = returnedObject._id.toString()
+    delete returnedObject._id
+    delete returnedObject.__v
+  }
+})
+
+groupSchema.plugin(uniqueValidator)
+
+module.exports = mongoose.model('Group', groupSchema)

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -25,6 +25,10 @@ const groupSchema = mongoose.Schema({
   publishDate: {
     type: Date,
     required: false
+  },
+  disabled: {
+    type: Boolean,
+    required: true
   }
 })
 

--- a/backend/setup.js
+++ b/backend/setup.js
@@ -7,6 +7,7 @@ const User = require('./models/user')
 const Extra = require('./models/extra')
 const Tag = require('./models/tag')
 const Form = require('./models/forms')
+const Group = require('./models/group')
 const mongoose = require('mongoose')
 
 beforeAll(async () => {
@@ -35,6 +36,7 @@ afterAll(async () => {
     await Extra.deleteMany({})
     await Tag.deleteMany({})
     await Form.deleteMany({})
+    await Group.deleteMany({})
     await mongoose.connection.close()
     console.log('test-mongodb connection closed')
   }

--- a/backend/tests/groupLogic.test.js
+++ b/backend/tests/groupLogic.test.js
@@ -1,0 +1,226 @@
+const { createTestClient } = require('apollo-server-testing')
+const { ApolloServer } = require('apollo-server-express')
+const bcrypt = require('bcrypt')
+
+const User = require('../models/user')
+const Event = require('../models/event')
+const Visit = require('../models/visit')
+const Group = require('../models/group')
+const { CREATE_VISIT, CANCEL_VISIT, CREATE_GROUP, UPDATE_GROUP, ASSIGN_EVENTS_TO_GROUP, DELETE_GROUP, createDate } = require('./testHelpers')
+const { details, eventData1 : eventDetails } = require('./testData')
+const typeDefs = require('../graphql/typeDefs')
+const resolvers = require('../graphql/resolvers')
+
+let server, serverNoUser
+let group1, group2, group3
+let event1, event2, event3
+
+const visitResponse = async (event, start, end) => {
+  const { mutate } = createTestClient(server)
+  return await mutate({
+    mutation: CREATE_VISIT,
+    variables: {
+      event,
+      ...details,
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+      token: 'token'
+    },
+  })
+}
+
+const cancelVisit = async (id) => {
+  const { mutate } = createTestClient(server)
+  return await mutate({
+    mutation: CANCEL_VISIT,
+    variables: { id },
+  })
+}
+
+const createGroup = async (name, maxCount, publishDate, isEmployee) => {
+  const { mutate } = createTestClient(isEmployee ? server : serverNoUser)
+  return await mutate({
+    mutation: CREATE_GROUP,
+    variables: {
+      name,
+      maxCount,
+      publishDate
+    }
+  })
+}
+
+const modifyGroup = async (id, name, maxCount, publishDate, isEmployee) => {
+  const { mutate } = createTestClient(isEmployee ? server : serverNoUser)
+  return await mutate({
+    mutation: UPDATE_GROUP,
+    variables: {
+      id,
+      name,
+      maxCount,
+      publishDate
+    }
+  })
+}
+
+const assignEventsToGroup = async (group, events) => {
+  const { mutate } = createTestClient(server)
+  return await mutate({
+    mutation: ASSIGN_EVENTS_TO_GROUP,
+    variables: {
+      group,
+      events
+    }
+  })
+}
+
+const deleteGroup = async (group) => {
+  const { mutate } = createTestClient(server)
+  return await mutate({
+    mutation: DELETE_GROUP,
+    variables: {
+      group
+    }
+  })
+}
+
+beforeAll(async () => {
+  await User.deleteMany({})
+
+  const userPassword = await bcrypt.hash('password', 10)
+  const userData = { username: 'employee', passwordHash: userPassword, isAdmin: false }
+
+  const user = new User(userData)
+  const savedUser = await user.save()
+
+  server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: async () => {
+      const currentUser = savedUser
+      return { currentUser }
+    }
+  })
+  serverNoUser = new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: async () => {
+      const currentUser = undefined
+      return { currentUser }
+    }
+  })
+})
+
+beforeEach(async () => {
+  await Event.deleteMany({})
+  await Visit.deleteMany({})
+  await Group.deleteMany({})
+  const groupDetails = {
+    visitCount: 0,
+    publishDate: null,
+    disabled: false
+  }
+
+  const data1 = new Group({
+    name: 'group1',
+    maxCount: 3,
+    visitCount: 0,
+    publishDate: new Date().toISOString(),
+    disabled: false
+  })
+  const data2 = new Group({
+    name: 'group2',
+    maxCount: 2,
+    ...groupDetails
+  })
+  const data3 = new Group({
+    name: 'group3',
+    maxCount: 1,
+    ...groupDetails
+  })
+  const eventData1 = new Event({ ...eventDetails })
+  const eventData2 = new Event({ ...eventDetails })
+  const eventData3 = new Event({ ...eventDetails })
+  group1 = await data1.save()
+  group2 = await data2.save()
+  group3 = await data3.save()
+  event1 = await eventData1.save()
+  event2 = await eventData2.save()
+  event3 = await eventData3.save()
+})
+
+describe('A group', () => {
+
+  it('can be created by an employee', async () => {
+    const response = await createGroup('group', 5, null, true)
+    expect(response.errors).toBeUndefined()
+    expect(response.data.createGroup.name).toBe('group')
+  })
+
+  it('cannot be created by an unauthorized user', async () => {
+    const response = await createGroup('nogroup', 5, null, false)
+    expect(response.errors[0].message).toBe('not authenticated')
+    expect(response.data.createGroup).toBe(null)
+  })
+
+  it('can be modified by an employee', async () => {
+    const response = await modifyGroup(group1.id, 'new name', 4, '', true)
+    const { name, maxCount, publishDate } = response.data.modifyGroup
+    expect(response.errors).toBeUndefined()
+    expect(name).toBe('new name')
+    expect(maxCount).toBe(4)
+    expect(publishDate).toBe(null)
+  })
+
+  it('cannot be modified by an unauthorized user', async () => {
+    const response = await modifyGroup(group1.id, 'name try', 5, '', false)
+    expect(response.errors[0].message).toBe('not authenticated')
+    expect(response.data.modifyGroup).toBe(null)
+  })
+
+  it('can be assigned to multiple events', async () => {
+    const response = await assignEventsToGroup(group1.id, [event1.id, event3.id])
+    expect(response.errors).toBeUndefined()
+    expect(response.data.assignEventsToGroup.length).toBe(2)
+    event1 = await Event.findById(event1.id)
+    event2 = await Event.findById(event2.id)
+    expect(event1.group.toString()).toBe(group1.id)
+    expect(event2.group).toBe(undefined)
+  })
+
+  it('can be deleted by an employee', async () => {
+    const response = await deleteGroup(group1.id)
+    expect(response.errors).toBeUndefined()
+    expect(response.data.deleteGroup).toBe(`Deleted Group with ID ${group1.id}`)
+  })
+
+  it('is disabled if it reaches maximum number of visits', async () => {
+    await assignEventsToGroup(group3.id, [event1.id])
+    await visitResponse(event1.id, createDate(11, 0), createDate(12, 0))
+    const data = await Group.findById(group3.id)
+    expect(data.name).toBe('group3')
+    expect(data.disabled).toBe(true)
+    expect(data.visitCount).toBe(1)
+  })
+
+  it('is not disabled if maximum number of visits is not exceeded', async () => {
+    await assignEventsToGroup(group2.id, [event1.id])
+    await visitResponse(event1.id, createDate(11, 0), createDate(12, 0))
+    const data = await Group.findById(group2.id)
+    expect(data.name).toBe('group2')
+    expect(data.disabled).toBe(false)
+    expect(data.visitCount).toBe(1)
+  })
+
+})
+
+describe('Visit', () => {
+
+  it('cannot be booked if maximum number of visits in the group is exceeded', async () => {
+    await assignEventsToGroup(group3.id, [event1.id, event2.id])
+    await visitResponse(event1.id, createDate(11, 0), createDate(12, 0))
+    const response = await visitResponse(event2.id, createDate(11, 0), createDate(12, 0))
+    expect(response.errors[0].message).toBe('this group is disabled')
+    expect(response.data.createVisit).toBe(null)
+  })
+
+})

--- a/backend/tests/testHelpers.js
+++ b/backend/tests/testHelpers.js
@@ -322,6 +322,8 @@ const UPDATE_EVENT = gql`
     $tags:[String]
     $start:String
     $end:String
+    $customForm: ID
+    $group: ID
   ) {
     modifyEvent(
       event: $event
@@ -337,6 +339,8 @@ const UPDATE_EVENT = gql`
       tags: $tags
       start: $start
       end: $end
+      customForm: $customForm
+      group: $group
     ) {
       id
       title
@@ -362,6 +366,12 @@ const UPDATE_EVENT = gql`
       tags {
         name,
         id
+      }
+      customForm
+      disabled
+      group {
+        id
+        name
       }
     }
   }

--- a/backend/tests/testHelpers.js
+++ b/backend/tests/testHelpers.js
@@ -476,6 +476,94 @@ const FORCE_DELETE_EVENTS = gql`
   }
 `
 
+const GET_GROUPS = gql`
+  query getGroups {
+    getGroups {
+      id
+      name
+      events {
+        id
+        title
+        resourceids
+        grades
+        remotePlatforms
+        otherRemotePlatformOption
+        start
+        end
+      }
+      maxCount
+      visitCount
+      publishDate
+      disabled
+    }
+  }
+`
+
+const CREATE_GROUP = gql`
+  mutation createGroup (
+    $name: String!
+    $maxCount: Int!
+    $publishDate: String
+  ) {
+    createGroup(
+      name: $name
+      maxCount: $maxCount
+      publishDate: $publishDate
+    ) {
+      id
+      name
+    }
+  }
+`
+
+const DELETE_GROUP = gql`
+  mutation deleteGroup(
+    $group: ID!
+  ) {
+    deleteGroup(
+      group: $group
+    )
+  }
+`
+
+const ASSIGN_EVENTS_TO_GROUP = gql`
+  mutation assignEventsToGroup(
+    $events: [ID]
+    $group: ID!
+  ) {
+    assignEventsToGroup(
+      group: $group
+      events: $events
+    ) {
+      id
+      title
+    }
+  }
+`
+
+const UPDATE_GROUP = gql`
+  mutation modifyGroup(
+    $id: ID!
+    $name: String
+    $maxCount: Int
+    $publishDate: String
+    $disabled: Boolean
+  ) {
+    modifyGroup(
+      id: $id
+      name: $name
+      maxCount: $maxCount
+      publishDate: $publishDate
+      disabled: $disabled
+    ) {
+      id
+      name
+      publishDate
+      maxCount
+    }
+  }
+`
+
 module.exports = {
   LOGIN,
   GET_ALL_VISITS,
@@ -500,6 +588,11 @@ module.exports = {
   LOCK_EVENT,
   UNLOCK_EVENT,
   FORCE_DELETE_EVENTS,
+  GET_GROUPS,
+  ASSIGN_EVENTS_TO_GROUP,
+  DELETE_GROUP,
+  UPDATE_GROUP,
+  CREATE_GROUP,
   createTimeList,
   createAvailableList,
   createDate,

--- a/frontend/cypress/integration/tests/admin/admin.spec.js
+++ b/frontend/cypress/integration/tests/admin/admin.spec.js
@@ -38,7 +38,7 @@ Given('Admin is logged in', () => {
 })
 
 When('I navigate to the user creation form', () => {
-  cy.get(':nth-child(8) > :nth-child(5) > .button').click()
+  cy.get(':nth-child(9) > :nth-child(1) > .button').click()
   cy.get(':nth-child(1) > .button').click()
 })
 
@@ -51,12 +51,12 @@ And('I enter new user credentials', () => {
 
 Then('the user is created', () => {
   cy.get('.toast').should('have.class', 'is-success')
-  cy.get(':nth-child(8) > :nth-child(5) > .button').click()
+  cy.get(':nth-child(9) > :nth-child(1) > .button').click()
   cy.contains('User123')
 })
 
 When('I navigate to the user list page', () => {
-  cy.get(':nth-child(8) > :nth-child(5) > .button').click()
+  cy.get(':nth-child(9) > :nth-child(1) > .button').click()
 })
 
 And('I click user deletion button', () => {

--- a/frontend/cypress/integration/tests/employee/employee.spec.js
+++ b/frontend/cypress/integration/tests/employee/employee.spec.js
@@ -85,10 +85,10 @@ When('I navigate to the event form', () => {
 And('I enter all necessary information', () => {
   cy.get('#title').type('Created event')
   cy.get('#duration').clear().type(80)
-  cy.get(':nth-child(3) > .taginput.control > .taginput-container > .autocomplete > .control > .input').type('Uusi tagi').type('{enter}')
-  cy.get(':nth-child(3) > .taginput.control > .taginput-container > .autocomplete > .dropdown-menu > .dropdown-content > :nth-child(2) > :nth-child(1)').click()
-  cy.get(':nth-child(13) > .checkbox2 > input').click()
-  cy.get(':nth-child(19) > label > input').click()
+  cy.get(':nth-child(4) > .taginput.control > .taginput-container > .autocomplete > .control > .input').type('Uusi tagi').type('{enter}')
+  cy.get(':nth-child(4) > .taginput.control > .taginput-container > .autocomplete > .dropdown-menu > .dropdown-content > :nth-child(2)').click()
+  cy.get(':nth-child(14) > .checkbox2 > input').click()
+  cy.get(':nth-child(20) > label > input').click()
   const eventDate = addDays(startOfWeek(new Date()), 16).toISOString().slice(0,10)
   cy.get(':nth-child(1) > .control > .ant-picker > .ant-picker-input > input').click()
   cy.get(`td[title="${eventDate}"]`).click()
@@ -150,8 +150,8 @@ And('I click modify event button', () => {
 
 And('I modify desired fields', () => {
   cy.get('#desc').clear().type('New description')
-  cy.get(':nth-child(19) > label > input').click()
   cy.get(':nth-child(20) > label > input').click()
+  cy.get(':nth-child(21) > label > input').click()
   cy.get('.modal-card-foot > .luma').click()
 })
 

--- a/frontend/cypress/integration/tests/view/view.spec.js
+++ b/frontend/cypress/integration/tests/view/view.spec.js
@@ -50,7 +50,7 @@ Then('I should see limited amount of buttons', () => {
   cy.contains('Lisäpalvelut')
   cy.contains('Lomakkeet')
   cy.contains('Käyttäjälista').should('not.exist')
-  cy.contains('Vierailulista').should('not.exist')
+  cy.contains('Vierailulista')
 })
 
 Then('I should not see admin or employee related buttons', () => {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1141,3 +1141,7 @@ form.luma hr,
 .select, .select select{ 
   width: 100%;
 }
+
+option {
+  font-size: 25px;
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1137,3 +1137,7 @@ form.luma hr,
   position: absolute;
   left: 0px
 }
+
+.select, .select select{ 
+  width: 100%;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -105,7 +105,8 @@ const App = () => {
       customForm: event.customForm,
       waitingTime: event.waitingTime,
       hasVisits: event.visits.length ? true : false,
-      locked: event.locked
+      locked: event.locked,
+      group: event.group
     }
     delete details.availableTimes
     delete details.visits

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -252,7 +252,9 @@ const App = () => {
           />
         </Route>
         <Route path='/group-list'>
-          <GroupList />
+          {currentUser &&
+            <GroupList />
+          }
         </Route>
         <Route path='/book'>
           <VisitForm currentUser={currentUser} event={clickedEvent} sendMessage={notify} token={sessionToken} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -25,6 +25,7 @@ import { useTranslation } from 'react-i18next'
 import EventList from './components/EventList'
 import EmailConfig from './components/EmailConfig'
 import { FaLock } from 'react-icons/fa'
+import GroupList from './components/GroupList'
 
 const App = () => {
   const { t } = useTranslation('common')
@@ -249,6 +250,9 @@ const App = () => {
             sendMessage={notify}
             tags={tags}
           />
+        </Route>
+        <Route path='/group-list'>
+          <GroupList />
         </Route>
         <Route path='/book'>
           <VisitForm currentUser={currentUser} event={clickedEvent} sendMessage={notify} token={sessionToken} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -217,7 +217,6 @@ const App = () => {
     const newToasts = toasts.concat({ id: toastID, message, type })
     setToasts(newToasts)
   }
-  if(result.data) console.log(result.data.getEvents)
 
   useEffect(() => {
     if (toasts.length) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -217,6 +217,7 @@ const App = () => {
     const newToasts = toasts.concat({ id: toastID, message, type })
     setToasts(newToasts)
   }
+  if(result.data) console.log(result.data.getEvents)
 
   useEffect(() => {
     if (toasts.length) {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -106,7 +106,6 @@ const App = () => {
       waitingTime: event.waitingTime,
       hasVisits: event.visits.length ? true : false,
       locked: event.locked,
-      group: event.group
     }
     delete details.availableTimes
     delete details.visits
@@ -115,14 +114,16 @@ const App = () => {
       start: new Date(timeSlot.startTime),
       end: new Date(timeSlot.endTime),
       booked: event.booked,
-      disabled: event.disabled
+      disabled: event.disabled,
+      group: event.group
     }))
     events = events.concat(event.visits.map(visit => Object({
       ...details,
       start: new Date(visit.startTime),
       end: new Date(visit.endTime),
       booked: true,
-      disabled: false
+      disabled: false,
+      group: null
     })))
 
     return events
@@ -275,8 +276,8 @@ const App = () => {
           {!(currentUser && currentUser.isAdmin) && <p>{t('not-logged-in')}</p>}
         </Route>
         <Route path='/events'>
-          {currentUser && currentUser.isAdmin && result.data &&
-            <EventList events={result.data.getEvents} sendMessage={notify} />
+          {currentUser && result.data &&
+            <EventList events={result.data.getEvents} sendMessage={notify} currentUser={currentUser} />
           }
         </Route>
         <Route path='/extras'>

--- a/frontend/src/MyCalendar.js
+++ b/frontend/src/MyCalendar.js
@@ -267,7 +267,7 @@ const MyCalendar = ({
           agenda: true
         }}
         showMultiDayTimes
-        events={localEvents.filter(event => filterFunction(event))}
+        events={localEvents.filter(event => event.group ? !event.group.disabled : true).filter(event => filterFunction(event))}
         startAccessor='start'
         endAccessor='end'
         min={set(new Date(), { hours: 8, minutes: 0, seconds:0, milliseconds: 0 })}

--- a/frontend/src/components/EventForm/Form.js
+++ b/frontend/src/components/EventForm/Form.js
@@ -47,7 +47,7 @@ const EventForm = ({ newEventTimeRange = null, closeEventForm, validate, onSubmi
         duration: event.duration,
         waitingTime: event.waitingTime,
         date: new Date(event.eventStart),
-        group: ''
+        group: event.group ? event.group : ''
       } : eventInitialValues(newEventTimeRange)}
       validate={validate}
       onSubmit={onSubmit}

--- a/frontend/src/components/EventForm/Form.js
+++ b/frontend/src/components/EventForm/Form.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { Field, Formik } from 'formik'
 import { useQuery } from '@apollo/client'
-import { EXTRAS, GET_ALL_FORMS } from '../../graphql/queries'
+import { EXTRAS, GET_ALL_FORMS, GET_GROUPS } from '../../graphql/queries'
 import LumaTagInput from '../LumaTagInput/LumaTagInput'
 import { TextArea, TextField } from '../VisitForm/FormFields'
 import { AdditionalServices, DatePick, EventType, Grades, Platforms, ScienceClasses, TimePick, SelectField } from './FormComponents'
@@ -12,8 +12,10 @@ const EventForm = ({ newEventTimeRange = null, closeEventForm, validate, onSubmi
   const { t } = useTranslation('event')
   const [suggestedTags, setSuggestedTags] = useState([])
   const [suggestedForms, setSuggestedForms] = useState([])
+  const [suggestedGroups, setSuggestedGroups] = useState([])
   const extras = useQuery(EXTRAS)
   const forms = useQuery(GET_ALL_FORMS)
+  const groups = useQuery(GET_GROUPS)
 
   useEffect(() => {
     if (tags) setSuggestedTags(tags)
@@ -22,6 +24,10 @@ const EventForm = ({ newEventTimeRange = null, closeEventForm, validate, onSubmi
   useEffect(() => {
     if (forms.data) setSuggestedForms(forms.data.getForms.map(form => Object({ id: form.id, name: form.name })))
   }, [forms.data])
+
+  useEffect(() => {
+    if (groups.data) setSuggestedGroups(groups.data.getGroups.map(group => Object({ id: group.id, name: group.name })))
+  }, [groups.data])
 
   return (
     <Formik
@@ -40,7 +46,8 @@ const EventForm = ({ newEventTimeRange = null, closeEventForm, validate, onSubmi
         endTime: new Date(event.eventEnd),
         duration: event.duration,
         waitingTime: event.waitingTime,
-        date: new Date(event.eventStart)
+        date: new Date(event.eventStart),
+        group: ''
       } : eventInitialValues(newEventTimeRange)}
       validate={validate}
       onSubmit={onSubmit}
@@ -58,6 +65,12 @@ const EventForm = ({ newEventTimeRange = null, closeEventForm, validate, onSubmi
                 fieldName='title'
                 component={TextField}
                 required={true}
+              />
+              <Field
+                label={t('group')}
+                fieldName='group'
+                options={suggestedGroups}
+                component={SelectField}
               />
 
               <Field

--- a/frontend/src/components/EventForm/Form.js
+++ b/frontend/src/components/EventForm/Form.js
@@ -47,7 +47,7 @@ const EventForm = ({ newEventTimeRange = null, closeEventForm, validate, onSubmi
         duration: event.duration,
         waitingTime: event.waitingTime,
         date: new Date(event.eventStart),
-        group: event.group ? event.group : ''
+        group: event.group ? event.group.id : ''
       } : eventInitialValues(newEventTimeRange)}
       validate={validate}
       onSubmit={onSubmit}

--- a/frontend/src/components/EventForm/index.js
+++ b/frontend/src/components/EventForm/index.js
@@ -105,7 +105,8 @@ export const EventForm = ({ sendMessage, addEvent, closeEventForm, newEventTimeR
         waitingTime: values.waitingTime,
         extras: values.extras,
         duration: values.duration,
-        customForm: values.customForm
+        customForm: values.customForm,
+        group: values.group ? values.group : null
       },
     })
   }

--- a/frontend/src/components/EventList.js
+++ b/frontend/src/components/EventList.js
@@ -15,7 +15,7 @@ const GroupModal = ({ setModalState, checkedEvents, events }) => {
   const groups = useQuery(GET_GROUPS)
   const [selectedGroup, setSelectedGroup] = useState('')
   const [assignEventsToGroup] = useMutation(ASSIGN_EVENTS_TO_GROUP, {
-    refetchQueries: [{ query: EVENTS }],
+    refetchQueries: [{ query: EVENTS }, { query: GET_GROUPS }],
     onError: (error) => console.log(error),
     onCompleted: () => setModalState(null)
   })
@@ -87,7 +87,6 @@ const EventList = ({ events, sendMessage }) => {
     }).sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime()))
     setCheckedEvents([])
   }, [startDate, endDate, events])
-  console.log(events)
 
   const [forceDeleteEvents] = useMutation(FORCE_DELETE_EVENTS, {
     refetchQueries: [{ query: EVENTS }],

--- a/frontend/src/components/EventList.js
+++ b/frontend/src/components/EventList.js
@@ -15,7 +15,7 @@ const GroupModal = ({ setModalState, checkedEvents, events }) => {
   const groups = useQuery(GET_GROUPS)
   const [selectedGroup, setSelectedGroup] = useState('')
   const [assignEventsToGroup] = useMutation(ASSIGN_EVENTS_TO_GROUP, {
-    refetchQueries: EVENTS,
+    refetchQueries: [{ query: EVENTS }],
     onError: (error) => console.log(error),
     onCompleted: () => setModalState(null)
   })
@@ -87,9 +87,10 @@ const EventList = ({ events, sendMessage }) => {
     }).sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime()))
     setCheckedEvents([])
   }, [startDate, endDate, events])
+  console.log(events)
 
   const [forceDeleteEvents] = useMutation(FORCE_DELETE_EVENTS, {
-    refetchQueries: EVENTS,
+    refetchQueries: [{ query: EVENTS }],
     onError: () => sendMessage(t('failed-to-remove-events'), 'danger'),
     onCompleted: () => {
       setModalState(null)
@@ -140,7 +141,11 @@ const EventList = ({ events, sendMessage }) => {
     <>
       <div className={`modal ${modalState === 'group' ? 'is-active':''}`}>
         <div className="modal-background"></div>
-        <GroupModal setModalState={setModalState} checkedEvents={checkedEvents} events={events} />
+        <GroupModal
+          setModalState={setModalState}
+          checkedEvents={checkedEvents}
+          events={events}
+        />
       </div>
       {modalState === 'delete' &&
         <div className={`modal ${modalState ? 'is-active': ''}`}>
@@ -215,7 +220,7 @@ const EventList = ({ events, sendMessage }) => {
               <th>{t('resource')}</th>
               <th>{t('date')}</th>
               <th>{t('time')}</th>
-              <th></th>
+              <th>{t('group')}</th>
             </tr>
           </thead>
           <tbody>
@@ -237,6 +242,7 @@ const EventList = ({ events, sendMessage }) => {
                   </td>
                   <td>{`${format(new Date(event.start), 'dd.MM.yyyy')}`}</td>
                   <td>{`${format(new Date(event.start), 'HH:mm')} - ${format(new Date(event.end), 'HH:mm')}`}</td>
+                  <td>{event.group ? event.group.name : ''}</td>
                 </tr>
               )
             })}

--- a/frontend/src/components/EventList.js
+++ b/frontend/src/components/EventList.js
@@ -68,7 +68,7 @@ const GroupModal = ({ setModalState, checkedEvents, events }) => {
   )
 }
 
-const EventList = ({ events, sendMessage }) => {
+const EventList = ({ events, sendMessage, currentUser }) => {
   const { t } = useTranslation('event')
   const history = useHistory()
   const [modalState, setModalState] = useState(null)
@@ -255,7 +255,9 @@ const EventList = ({ events, sendMessage }) => {
         </table>
         <div className="field is-grouped">
           <button className="button luma primary" onClick={openGroupModal} >{t('assign-to-group')}</button>
-          <button className="button luma primary" onClick={openDeleteModal} >{t('delete-choosen-events')}</button>
+          {currentUser.isAdmin &&
+            <button className="button luma primary" onClick={openDeleteModal} >{t('delete-choosen-events')}</button>
+          }
           <div className="control">
             <button className="button luma" onClick={showAll} >{t('show-all')}</button>
           </div>

--- a/frontend/src/components/EventList.js
+++ b/frontend/src/components/EventList.js
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@apollo/client'
-import { format } from 'date-fns'
+import { addYears, format } from 'date-fns'
 import { Field, Formik } from 'formik'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -127,6 +127,10 @@ const EventList = ({ events, sendMessage }) => {
     values.password = ''
   }
 
+  const showAll = () => {
+    setEndDate(addYears(new Date(), 10))
+  }
+
   const handleChooseAll = () => {
     if (checkedEvents.length === tableEvents.length) {
       setCheckedEvents([])
@@ -220,6 +224,7 @@ const EventList = ({ events, sendMessage }) => {
               <th>{t('date')}</th>
               <th>{t('time')}</th>
               <th>{t('group')}</th>
+              <th>{t('has-visits')}</th>
             </tr>
           </thead>
           <tbody>
@@ -242,6 +247,7 @@ const EventList = ({ events, sendMessage }) => {
                   <td>{`${format(new Date(event.start), 'dd.MM.yyyy')}`}</td>
                   <td>{`${format(new Date(event.start), 'HH:mm')} - ${format(new Date(event.end), 'HH:mm')}`}</td>
                   <td>{event.group ? event.group.name : ''}</td>
+                  <td>{event.visits.length}</td>
                 </tr>
               )
             })}
@@ -250,6 +256,9 @@ const EventList = ({ events, sendMessage }) => {
         <div className="field is-grouped">
           <button className="button luma primary" onClick={openGroupModal} >{t('assign-to-group')}</button>
           <button className="button luma primary" onClick={openDeleteModal} >{t('delete-choosen-events')}</button>
+          <div className="control">
+            <button className="button luma" onClick={showAll} >{t('show-all')}</button>
+          </div>
           <div className="control">
             <button className="button luma" onClick={handleChooseAll} >{checkedEvents.length !== tableEvents.length ? t('choose-all') : t('deselect')}</button>
           </div>

--- a/frontend/src/components/GroupList.js
+++ b/frontend/src/components/GroupList.js
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@apollo/client'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
-import { CREATE_GROUP, GET_GROUPS } from '../graphql/queries'
+import { CREATE_GROUP, DELETE_GROUP, GET_GROUPS } from '../graphql/queries'
 
 const GroupList = () => {
   const { t } = useTranslation('common')
@@ -11,6 +11,11 @@ const GroupList = () => {
   const [maxCount, setMaxCount] = useState('')
   const groups = useQuery(GET_GROUPS)
   const [createGroup] = useMutation(CREATE_GROUP, {
+    refetchQueries: GET_GROUPS,
+    onError: error => console.log(error),
+    onCompleted: () => groups.refetch()
+  })
+  const [deleteGroup] = useMutation(DELETE_GROUP, {
     refetchQueries: GET_GROUPS,
     onError: error => console.log(error),
     onCompleted: () => groups.refetch()
@@ -33,6 +38,14 @@ const GroupList = () => {
     setMaxCount('')
   }
 
+  const handleRemove = (group) => {
+    deleteGroup({
+      variables: {
+        group
+      }
+    })
+  }
+
   return (
     <div className="section">
       <h1 className="title">{t('groups')}</h1>
@@ -43,6 +56,7 @@ const GroupList = () => {
             <th>{t('max-number-of-visits')}</th>
             <th>{t('number-of-booked-visits')}</th>
             <th>{t('publish-date')}</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -52,6 +66,9 @@ const GroupList = () => {
               <td>{group.maxCount}</td>
               <td>{group.visitCount}</td>
               <td>{group.publishDate}</td>
+              <td>
+                <button className="button luma" onClick={() => handleRemove(group.id)}>{t('remove')}</button>
+              </td>
             </tr>
           )}
         </tbody>

--- a/frontend/src/components/GroupList.js
+++ b/frontend/src/components/GroupList.js
@@ -1,0 +1,82 @@
+import { useMutation, useQuery } from '@apollo/client'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useHistory } from 'react-router-dom'
+import { CREATE_GROUP, GET_GROUPS } from '../graphql/queries'
+
+const GroupList = () => {
+  const { t } = useTranslation('common')
+  const history = useHistory()
+  const [name, setName] = useState('')
+  const [maxCount, setMaxCount] = useState('')
+  const groups = useQuery(GET_GROUPS)
+  const [createGroup] = useMutation(CREATE_GROUP, {
+    refetchQueries: GET_GROUPS,
+    onError: error => console.log(error),
+    onCompleted: () => groups.refetch()
+  })
+  if (groups.loading) return <></>
+  console.log(groups)
+
+  const handleBack = () => {
+    history.push('/')
+  }
+
+  const addGroup = () => {
+    createGroup({
+      variables: {
+        name,
+        maxCount
+      }
+    })
+    setName('')
+    setMaxCount('')
+  }
+
+  return (
+    <div className="section">
+      <h1 className="title">{t('groups')}</h1>
+      <table className="table" style={{ marginTop: 10 }}>
+        <thead>
+          <tr>
+            <th>{t('name')}</th>
+            <th>{t('max-number-of-visits')}</th>
+            <th>{t('number-of-booked-visits')}</th>
+            <th>{t('publish-date')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.data.getGroups.map(group =>
+            <tr key={group.id}>
+              <td>{group.name}</td>
+              <td>{group.maxCount}</td>
+              <td>{group.visitCount}</td>
+              <td>{group.publishDate}</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <div className="field is-grouped">
+        <input
+          className="input"
+          value={name}
+          placeholder={t('name')}
+          style={{ width: 150, marginRight: 10 }}
+          onChange={(event) => setName(event.target.value)}
+        />
+        <input
+          className="input"
+          type="number"
+          value={maxCount}
+          placeholder={t('max-count')}
+          style={{ width: 150, marginRight: 10 }}
+          onChange={(event) => setMaxCount(Number(event.target.value))}
+        />
+        <button className="button luma primary" onClick={addGroup} >{t('add-group')}</button>
+        <button className="button luma" onClick={handleBack} >{t('back')}</button>
+      </div>
+    </div>
+  )
+}
+
+export default GroupList

--- a/frontend/src/components/GroupList.js
+++ b/frontend/src/components/GroupList.js
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@apollo/client'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
-import { CREATE_GROUP, DELETE_GROUP, GET_GROUPS } from '../graphql/queries'
+import { CREATE_GROUP, DELETE_GROUP, EVENTS, GET_GROUPS } from '../graphql/queries'
 
 const GroupList = () => {
   const { t } = useTranslation('common')
@@ -16,12 +16,10 @@ const GroupList = () => {
     onCompleted: () => groups.refetch()
   })
   const [deleteGroup] = useMutation(DELETE_GROUP, {
-    refetchQueries: GET_GROUPS,
+    refetchQueries: [{ query: GET_GROUPS }, { query: EVENTS }],
     onError: error => console.log(error),
-    onCompleted: () => groups.refetch()
   })
   if (groups.loading) return <></>
-  console.log(groups)
 
   const handleBack = () => {
     history.push('/')
@@ -56,6 +54,7 @@ const GroupList = () => {
             <th>{t('max-number-of-visits')}</th>
             <th>{t('number-of-booked-visits')}</th>
             <th>{t('publish-date')}</th>
+            <th>{t('number-of-events')}</th>
             <th></th>
           </tr>
         </thead>
@@ -66,6 +65,7 @@ const GroupList = () => {
               <td>{group.maxCount}</td>
               <td>{group.visitCount}</td>
               <td>{group.publishDate}</td>
+              <td>{group.events.length}</td>
               <td>
                 <button className="button luma" onClick={() => handleRemove(group.id)}>{t('remove')}</button>
               </td>

--- a/frontend/src/components/GroupList.js
+++ b/frontend/src/components/GroupList.js
@@ -18,7 +18,7 @@ const GroupList = () => {
     onError: error => console.log(error)
   })
   const [modifyGroup] = useMutation(UPDATE_GROUP, {
-    refetchQueries: [{ query: GET_GROUPS }],
+    refetchQueries: [{ query: GET_GROUPS }, { query: EVENTS }],
     onError: error => console.log(error)
   })
   const [deleteGroup] = useMutation(DELETE_GROUP, {
@@ -100,7 +100,7 @@ const GroupList = () => {
             <th>{t('name')}</th>
             <th>{t('max-number-of-visits')}</th>
             <th>{t('number-of-booked-visits')}</th>
-            <th>{t('publish-date')}</th>
+            <th>{t('publish')}</th>
             <th>{t('number-of-events')}</th>
             <th>{t('disabled')}</th>
             <th></th>

--- a/frontend/src/components/ModifyEventModal/Form.js
+++ b/frontend/src/components/ModifyEventModal/Form.js
@@ -45,7 +45,7 @@ const Form = ({ event, close, save, validate, tags }) => {
         startTime: new Date(event.eventStart),
         endTime: new Date(event.eventEnd),
         customForm: event.customForm ? event.customForm : '',
-        group: event.group ? event.group : ''
+        group: event.group ? event.group.id : ''
       }}
       validate={validate}
       onSubmit={save}

--- a/frontend/src/components/ModifyEventModal/Form.js
+++ b/frontend/src/components/ModifyEventModal/Form.js
@@ -2,7 +2,7 @@ import { useQuery } from '@apollo/client'
 import { Field, Formik } from 'formik'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { EXTRAS, GET_ALL_FORMS } from '../../graphql/queries'
+import { EXTRAS, GET_ALL_FORMS, GET_GROUPS } from '../../graphql/queries'
 import { createGradeList, createPlatformList, createResourceList } from '../../helpers/form'
 import { AdditionalServices, EventType, Grades, Platforms, ScienceClasses, TimePick, SelectField } from '../EventForm/FormComponents'
 import LumaTagInput from '../LumaTagInput/LumaTagInput'
@@ -12,8 +12,10 @@ const Form = ({ event, close, save, validate, tags }) => {
   const { t } = useTranslation('event')
   const [suggestedTags, setSuggestedTags] = useState([])
   const [suggestedForms, setSuggestedForms] = useState([])
+  const [suggestedGroups, setSuggestedGroups] = useState([])
   const extras = useQuery(EXTRAS)
   const forms = useQuery(GET_ALL_FORMS)
+  const groups = useQuery(GET_GROUPS)
 
   useEffect(() => {
     if (tags) setSuggestedTags(tags)
@@ -22,6 +24,10 @@ const Form = ({ event, close, save, validate, tags }) => {
   useEffect(() => {
     if (forms.data) setSuggestedForms(forms.data.getForms.map(form => Object({ id: form.id, name: form.name })))
   }, [forms.data])
+
+  useEffect(() => {
+    if (groups.data) setSuggestedGroups(groups.data.getGroups.map(group => Object({ id: group.id, name: group.name })))
+  }, [groups.data])
 
   return (
     <Formik
@@ -38,7 +44,8 @@ const Form = ({ event, close, save, validate, tags }) => {
         tags: event.tags.map(tag => tag.name),
         startTime: new Date(event.eventStart),
         endTime: new Date(event.eventEnd),
-        customForm: event.customForm
+        customForm: event.customForm ? event.customForm : '',
+        group: event.group ? event.group : ''
       }}
       validate={validate}
       onSubmit={save}
@@ -56,6 +63,12 @@ const Form = ({ event, close, save, validate, tags }) => {
                 fieldName='title'
                 component={TextField}
                 required={true}
+              />
+              <Field
+                label={t('group')}
+                fieldName='group'
+                options={suggestedGroups}
+                component={SelectField}
               />
               <Field
                 label={t('description')}

--- a/frontend/src/components/ModifyEventModal/index.js
+++ b/frontend/src/components/ModifyEventModal/index.js
@@ -90,7 +90,8 @@ export const ModifyEvent = ({ event, close, setEvent, sendMessage, tags }) => {
     tags,
     startTime,
     endTime,
-    customForm
+    customForm,
+    group
   }) => {
     const gradeList = []
     grades.forEach((element, index) => element ? gradeList.push(index + 1) : null)
@@ -116,7 +117,8 @@ export const ModifyEvent = ({ event, close, setEvent, sendMessage, tags }) => {
         tags,
         start: startTime.toISOString(),
         end: endTime.toISOString(),
-        customForm: customForm
+        customForm: customForm.length ? customForm : null,
+        group: group.length ? group : null
       }
     })
   }

--- a/frontend/src/components/ModifyEventModal/index.js
+++ b/frontend/src/components/ModifyEventModal/index.js
@@ -2,7 +2,7 @@ import { useMutation } from '@apollo/client'
 import { format } from 'date-fns'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { EVENTS, UPDATE_EVENT } from '../../graphql/queries'
+import { EVENTS, GET_GROUPS, UPDATE_EVENT } from '../../graphql/queries'
 import Form from './Form'
 
 export const ModifyEvent = ({ event, close, setEvent, sendMessage, tags }) => {
@@ -62,7 +62,7 @@ export const ModifyEvent = ({ event, close, setEvent, sendMessage, tags }) => {
   }
 
   const [create] = useMutation(UPDATE_EVENT, {
-    refetchQueries: [{ query: EVENTS }],
+    refetchQueries: [{ query: EVENTS }, { query: GET_GROUPS }],
     onCompleted: ({ modifyEvent }) => {
       const start = new Date(modifyEvent.start)
       const end = new Date(modifyEvent.end)

--- a/frontend/src/components/ModifyEventModal/index.js
+++ b/frontend/src/components/ModifyEventModal/index.js
@@ -118,7 +118,7 @@ export const ModifyEvent = ({ event, close, setEvent, sendMessage, tags }) => {
         start: startTime.toISOString(),
         end: endTime.toISOString(),
         customForm: customForm.length ? customForm : null,
-        group: group.length ? group : null
+        group: group.length ? group : ''
       }
     })
   }

--- a/frontend/src/components/UserPage.js
+++ b/frontend/src/components/UserPage.js
@@ -66,19 +66,19 @@ const UserPage = ({ currentUser, setShowEventForm }) => {
         <div className="control">
           <button className="button luma" onClick={groups}>{t('groups')}</button>
         </div>
+        <div className="control">
+          <button className="button luma" onClick={eventList}>{t('event-list')}</button>
+        </div>
       </div>
       <div className="field is-grouped">
         {currentUser.isAdmin &&
         <>
-          <p className="control">
+          <div className="control">
             <button className="button luma" onClick={listUsers}>{t('user-list')}</button>
-          </p>
-          <p className="control">
-            <button className="button luma" onClick={eventList}>{t('event-list')}</button>
-          </p>
-          <p className="control">
+          </div>
+          <div className="control">
             <button className="button luma" onClick={emailConfig}>{t('email-config')}</button>
-          </p>
+          </div>
         </>
         }
       </div>

--- a/frontend/src/components/UserPage.js
+++ b/frontend/src/components/UserPage.js
@@ -41,23 +41,34 @@ const UserPage = ({ currentUser, setShowEventForm }) => {
     history.push('/email-config')
   }
 
+  const groups = (event) => {
+    event.preventDefault()
+    history.push('/group-list')
+  }
+
   if (!currentUser) return <div></div>
 
   return (
-    <div className="field is-grouped">
-      <p className="control">
-        <button className="button luma" onClick={createEvent}>{t('create-visit')}</button>
-      </p>
-      <p className="control">
-        <button className="button luma" onClick={listVisits}>{t('reservations')}</button>
-      </p>
-      <p className="control">
-        <button className="button luma" onClick={extras}>{t('extras')}</button>
-      </p>
-      <p className="control">
-        <button className="button luma" onClick={forms}>{t('forms')}</button>
-      </p>
-      {currentUser.isAdmin &&
+    <>
+      <div className="field is-grouped">
+        <div className="control">
+          <button className="button luma" onClick={createEvent}>{t('create-visit')}</button>
+        </div>
+        <div className="control">
+          <button className="button luma" onClick={listVisits}>{t('reservations')}</button>
+        </div>
+        <div className="control">
+          <button className="button luma" onClick={extras}>{t('extras')}</button>
+        </div>
+        <div className="control">
+          <button className="button luma" onClick={forms}>{t('forms')}</button>
+        </div>
+        <div className="control">
+          <button className="button luma" onClick={groups}>{t('groups')}</button>
+        </div>
+      </div>
+      <div className="field is-grouped">
+        {currentUser.isAdmin &&
         <>
           <p className="control">
             <button className="button luma" onClick={listUsers}>{t('user-list')}</button>
@@ -69,8 +80,9 @@ const UserPage = ({ currentUser, setShowEventForm }) => {
             <button className="button luma" onClick={emailConfig}>{t('email-config')}</button>
           </p>
         </>
-      }
-    </div>
+        }
+      </div>
+    </>
   )
 }
 

--- a/frontend/src/components/UserPage.spec.js
+++ b/frontend/src/components/UserPage.spec.js
@@ -95,6 +95,6 @@ test('History should be set to /users', async () => {
   )
   await waitFor(() => new Promise((res) => setTimeout(res, 0))) // Allow component time to render
   const buttons = container.querySelectorAll('.button.luma')
-  fireEvent.click(buttons[4])
+  fireEvent.click(buttons[5])
   expect(history.location.pathname).toBe('/users')
 })

--- a/frontend/src/components/UserPage.spec.js
+++ b/frontend/src/components/UserPage.spec.js
@@ -95,6 +95,6 @@ test('History should be set to /users', async () => {
   )
   await waitFor(() => new Promise((res) => setTimeout(res, 0))) // Allow component time to render
   const buttons = container.querySelectorAll('.button.luma')
-  fireEvent.click(buttons[5])
+  fireEvent.click(buttons[6])
   expect(history.location.pathname).toBe('/users')
 })

--- a/frontend/src/components/VisitForm/index.js
+++ b/frontend/src/components/VisitForm/index.js
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@apollo/client'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
-import { CREATE_VISIT, EVENTS, GET_FORM } from '../../graphql/queries'
+import { CREATE_VISIT, EVENTS, GET_FORM, GET_GROUPS } from '../../graphql/queries'
 import Form from './Form'
 
 const calculateVisitEndTime = (startTimeAsDate, values, selectedEvent, extras) => {
@@ -43,7 +43,7 @@ export const VisitForm = ({ sendMessage, event, token }) => {
     : { loading: null, error: null, data: null }
 
   const [create, result] = useMutation(CREATE_VISIT, {
-    refetchQueries: [{ query: EVENTS }],
+    refetchQueries: [{ query: EVENTS }, { query: GET_GROUPS }],
     onError: (error) => {
       console.log(error)
       if (error.message === 'File not found') {

--- a/frontend/src/components/__snapshots__/UserPage.spec.js.snap
+++ b/frontend/src/components/__snapshots__/UserPage.spec.js.snap
@@ -50,20 +50,7 @@ exports[`Renders without error with admin user 1`] = `
         Ryhmät
       </button>
     </div>
-  </div>
-  <div
-    class="field is-grouped"
-  >
-    <p
-      class="control"
-    >
-      <button
-        class="button luma"
-      >
-        Käyttäjälista
-      </button>
-    </p>
-    <p
+    <div
       class="control"
     >
       <button
@@ -71,8 +58,21 @@ exports[`Renders without error with admin user 1`] = `
       >
         Vierailulista
       </button>
-    </p>
-    <p
+    </div>
+  </div>
+  <div
+    class="field is-grouped"
+  >
+    <div
+      class="control"
+    >
+      <button
+        class="button luma"
+      >
+        Käyttäjälista
+      </button>
+    </div>
+    <div
       class="control"
     >
       <button
@@ -80,7 +80,7 @@ exports[`Renders without error with admin user 1`] = `
       >
         Sähköpostit
       </button>
-    </p>
+    </div>
   </div>
 </div>
 `;
@@ -139,6 +139,15 @@ exports[`Renders without error with user 1`] = `
         class="button luma"
       >
         Ryhmät
+      </button>
+    </div>
+    <div
+      class="control"
+    >
+      <button
+        class="button luma"
+      >
+        Vierailulista
       </button>
     </div>
   </div>

--- a/frontend/src/components/__snapshots__/UserPage.spec.js.snap
+++ b/frontend/src/components/__snapshots__/UserPage.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Renders without error with admin user 1`] = `
   <div
     class="field is-grouped"
   >
-    <p
+    <div
       class="control"
     >
       <button
@@ -13,8 +13,8 @@ exports[`Renders without error with admin user 1`] = `
       >
         Luo uusi vierailu
       </button>
-    </p>
-    <p
+    </div>
+    <div
       class="control"
     >
       <button
@@ -22,8 +22,8 @@ exports[`Renders without error with admin user 1`] = `
       >
         Varaukset
       </button>
-    </p>
-    <p
+    </div>
+    <div
       class="control"
     >
       <button
@@ -31,8 +31,8 @@ exports[`Renders without error with admin user 1`] = `
       >
         Lisäpalvelut
       </button>
-    </p>
-    <p
+    </div>
+    <div
       class="control"
     >
       <button
@@ -40,7 +40,20 @@ exports[`Renders without error with admin user 1`] = `
       >
         Lomakkeet
       </button>
-    </p>
+    </div>
+    <div
+      class="control"
+    >
+      <button
+        class="button luma"
+      >
+        Ryhmät
+      </button>
+    </div>
+  </div>
+  <div
+    class="field is-grouped"
+  >
     <p
       class="control"
     >
@@ -83,7 +96,7 @@ exports[`Renders without error with user 1`] = `
   <div
     class="field is-grouped"
   >
-    <p
+    <div
       class="control"
     >
       <button
@@ -91,8 +104,8 @@ exports[`Renders without error with user 1`] = `
       >
         Luo uusi vierailu
       </button>
-    </p>
-    <p
+    </div>
+    <div
       class="control"
     >
       <button
@@ -100,8 +113,8 @@ exports[`Renders without error with user 1`] = `
       >
         Varaukset
       </button>
-    </p>
-    <p
+    </div>
+    <div
       class="control"
     >
       <button
@@ -109,8 +122,8 @@ exports[`Renders without error with user 1`] = `
       >
         Lisäpalvelut
       </button>
-    </p>
-    <p
+    </div>
+    <div
       class="control"
     >
       <button
@@ -118,7 +131,19 @@ exports[`Renders without error with user 1`] = `
       >
         Lomakkeet
       </button>
-    </p>
+    </div>
+    <div
+      class="control"
+    >
+      <button
+        class="button luma"
+      >
+        Ryhmät
+      </button>
+    </div>
   </div>
+  <div
+    class="field is-grouped"
+  />
 </div>
 `;

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -198,7 +198,10 @@ export const CREATE_EVENT = gql`
       disabled
       waitingTime
       locked
-      group
+      group {
+        id
+        name
+      }
     }
   }
 `
@@ -428,7 +431,10 @@ export const UPDATE_EVENT = gql`
       }
       customForm
       disabled
-      group
+      group {
+        id
+        name
+      }
     }
   }
 `

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -71,6 +71,7 @@ export const EVENTS = gql`
       customForm
       disabled
       locked
+      group
     }
   }
 `
@@ -378,6 +379,7 @@ export const UPDATE_EVENT = gql`
     $start:String
     $end:String
     $customForm: ID
+    $group: ID
   ) {
     modifyEvent(
       event: $event
@@ -394,6 +396,7 @@ export const UPDATE_EVENT = gql`
       start: $start
       end: $end
       customForm: $customForm
+      group: $group
     ) {
       id
       title
@@ -422,6 +425,7 @@ export const UPDATE_EVENT = gql`
       }
       customForm
       disabled
+      group
     }
   }
 `
@@ -676,5 +680,15 @@ export const CREATE_GROUP = gql`
       id
       name
     }
+  }
+`
+
+export const DELETE_GROUP = gql`
+  mutation deleteGroup(
+  $group: ID!
+  ) {
+    deleteGroup(
+      group: $group
+    )
   }
 `

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -674,6 +674,7 @@ export const GET_GROUPS = gql`
       maxCount
       visitCount
       publishDate
+      disabled
     }
   }
 `
@@ -716,6 +717,27 @@ export const ASSIGN_EVENTS_TO_GROUP = gql`
     ) {
       id
       title
+    }
+  }
+`
+
+export const UPDATE_GROUP = gql`
+  mutation modifyGroup(
+    $id: ID!
+    $name: String
+    $maxCount: Int
+    $publishDate: String
+    $disabled: Boolean
+  ) {
+    modifyGroup(
+      id: $id
+      name: $name
+      maxCount: $maxCount
+      publishDate: $publishDate
+      disabled: $disabled
+    ) {
+      id
+      name
     }
   }
 `

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -673,6 +673,7 @@ export const GET_GROUPS = gql`
       }
       maxCount
       visitCount
+      publishDate
     }
   }
 `
@@ -681,10 +682,12 @@ export const CREATE_GROUP = gql`
   mutation createGroup (
     $name: String!
     $maxCount: Int!
+    $publishDate: String
   ) {
     createGroup(
       name: $name
       maxCount: $maxCount
+      publishDate: $publishDate
     ) {
       id
       name

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -74,6 +74,7 @@ export const EVENTS = gql`
       group {
         id
         name
+        disabled
       }
     }
   }

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -685,10 +685,25 @@ export const CREATE_GROUP = gql`
 
 export const DELETE_GROUP = gql`
   mutation deleteGroup(
-  $group: ID!
+    $group: ID!
   ) {
     deleteGroup(
       group: $group
     )
+  }
+`
+
+export const ASSIGN_EVENTS_TO_GROUP = gql`
+  mutation assignEventsToGroup(
+    $events: [ID]
+    $group: ID!
+  ) {
+    assignEventsToGroup(
+      group: $group
+      events: $events
+    ) {
+      id
+      title
+    }
   }
 `

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -139,7 +139,8 @@ export const CREATE_EVENT = gql`
     $waitingTime: Int!
     $extras: [ID]
     $duration: Int!,
-    $customForm: ID
+    $customForm: ID,
+    $group: ID,
     ) {
     createEvent (
       title: $title,
@@ -157,6 +158,7 @@ export const CREATE_EVENT = gql`
       extras: $extras
       duration: $duration
       customForm: $customForm
+      group: $group
     ) {
       id
       title
@@ -192,6 +194,7 @@ export const CREATE_EVENT = gql`
       disabled
       waitingTime
       locked
+      group
     }
   }
 `
@@ -635,6 +638,42 @@ export const UPDATE_EMAIL = gql`
       adSubject: $adSubject
       adText: $adText
     ) {
+      name
+    }
+  }
+`
+
+export const GET_GROUPS = gql`
+  query getGroups {
+    getGroups {
+      id
+      name
+      events {
+        id
+        title
+        resourceids
+        grades
+        remotePlatforms
+        otherRemotePlatformOption
+        start
+        end
+      }
+      maxCount
+      visitCount
+    }
+  }
+`
+
+export const CREATE_GROUP = gql`
+  mutation createGroup (
+    $name: String!
+    $maxCount: Int!
+  ) {
+    createGroup(
+      name: $name
+      maxCount: $maxCount
+    ) {
+      id
       name
     }
   }

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -71,7 +71,10 @@ export const EVENTS = gql`
       customForm
       disabled
       locked
-      group
+      group {
+        id
+        name
+      }
     }
   }
 `

--- a/frontend/src/locales/fi/common.json
+++ b/frontend/src/locales/fi/common.json
@@ -75,5 +75,18 @@
   "notification-to": "Lähetä ilmoitus osoitteisiin",
   "ad-subject": "Ilmoituksen aihe",
   "ad-text": "Ilmoituksen sisältö",
-  "add-address": "Lisää osoite"
+  "add-address": "Lisää osoite",
+  "max-number-of-visits": "Varausmaksimi",
+  "number-of-booked-visits": "Varausten määrä",
+  "publish": "Julkaisu ajankohta",
+  "number-of-events": "Vierailujen määrä",
+  "add-group": "Lisää ryhmä",
+  "max-count": "Maksimi määrä",
+  "publish-date": "Julkaisupäivä",
+  "publish-time": "Kellonaika",
+  "no": "Ei",
+  "yes": "Kyllä",
+  "change-details": "Muuta tietoja",
+  "update": "Päivitä",
+  "groups": "Ryhmät"
 }

--- a/frontend/src/locales/fi/event.json
+++ b/frontend/src/locales/fi/event.json
@@ -111,5 +111,10 @@
   "deselect": "Poista valinnat",
   "hide-events-to-be-removed": "Piilota poistettavien vierailujen nimet",
   "show-events-to-be-removed": "Näytä poistettavien vierailujen nimet",
-  "no-events-chosen": "Ei vierailuja valittu"
+  "no-events-chosen": "Ei vierailuja valittu",
+  "assign-to-group": "Lisää ryhmään",
+  "show-all": "Näytä kaikki",
+  "group": "Ryhmä",
+  "has-visits": "Varausten määrä",
+  "assign-events-to-group": "Lisää vierailut ryhmään"
 }

--- a/frontend/src/locales/fi/user.json
+++ b/frontend/src/locales/fi/user.json
@@ -60,5 +60,6 @@
   "text": "Tekstikenttä",
   "checkbox": "Rastiruutu",
   "radio": "Radio-valinta",
-  "email-config": "Sähköpostit"
+  "email-config": "Sähköpostit",
+  "groups": "Ryhmät"
 }


### PR DESCRIPTION
Lisätty toiminnallisuus ryhmittää vierailuja.
Vierailu voidaan asettaa ryhmään vierailu listassa.
Ryhmä voidaan luoda ryhmälistauksessa.
Vierailun ryhmää voidaan vaihtaa, jolloin varauslaskurin tulos kasvaa uudelle ryhmälle ja vähenee vanhalta ryhmältä.
Ryhmälle voidaan asettaa julkaisuajankohta.
Ryhmä lukittuu jos varausten maksimimäärä täyttyy, eikä sitä voida tällä hetkellä avata mitenkään.
Lukitussa ryhmässä olevat available timet eivät ole nähtävissä kalenterinäkymässä kenellekkään.
Lukitun ryhmän vierailut näkyvät vierailulistauksessa.
Lisätty backendiin testejä testaamaan lisättyäjä ominaisuuksia.
Ryhmän tietoja voidaan muokata ja se voidaan poistaa, jolloin siihen liitetyt vierailut eivät enään sisällä tietoa ryhmästä.
Lukitun ryhmän varauksen peruminen ei avaa ryhmää, mutta luo uuden vierailun varauksen omalla aikaikkunalla.